### PR TITLE
Minor code and tests cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,17 @@ The parameter `maxN` could also be named 'adaptation window', and a good rule of
 thumb to choose a starting value is thinking how many observations it would take
 to make a reasonably accurate new estimation of statistical parameters after a
 change in their distribution in your application.
+
+## Running tests
+
+For a quick run, try:
+
+```shell
+go test -short -race -cover ./...
+```
+
+For the full suite, which includes testing against randomly generated data, try:
+
+```shell
+go test -race -cover ./...
+```

--- a/adaptive_pool_test.go
+++ b/adaptive_pool_test.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 )
 
+var (
+	_ PoolItemProvider[[]byte]        = NormalSlice[byte]{}
+	_ PoolItemProvider[*bytes.Buffer] = NormalBytesBuffer{}
+)
+
 func TestAdaptivePool(t *testing.T) {
 	t.Parallel()
 

--- a/stats_bench_test.go
+++ b/stats_bench_test.go
@@ -8,8 +8,7 @@ func BenchmarkStats(b *testing.B) {
 	//	go test -run=- -bench=Stats/implem -count=20 | benchstat -col=/implem -
 
 	values := allTestDataInputValues(b)
-	b.Run("implem=stats1", benchStats(new(stats1), values))
-	b.Run("implem=stats2", benchStats(new(stats2), values))
+	b.Run("implem=default", benchStats(new(Stats), values))
 }
 
 func benchStats(st stats, values []float64) func(b *testing.B) {

--- a/stats_bench_test.go
+++ b/stats_bench_test.go
@@ -8,7 +8,6 @@ func BenchmarkStats(b *testing.B) {
 	//	go test -run=- -bench=Stats/implem -count=20 | benchstat -col=/implem -
 
 	values := allTestDataInputValues(b)
-	b.Run("implem=stats0", benchStats(new(stats0), values))
 	b.Run("implem=stats1", benchStats(new(stats1), values))
 	b.Run("implem=stats2", benchStats(new(stats2), values))
 }


### PR DESCRIPTION
- Remove the testing `stats0` and `stats2` implementation.
- Move initialization of `AdaptivePool` to a different function rather than in situ in the exported function.
- Move interface satisfaction assertions to tests.
- Add testing information in README.md