### PR TITLE
Add ReaderBufferer

### DIFF
--- a/adaptive_pool.go
+++ b/adaptive_pool.go
@@ -16,13 +16,13 @@ import (
 type PoolItemProvider[T any] interface {
 	// Sizeof measures the size of an item. This measurement is used to compute
 	// stats that allow efficiently reusing and creating items in an
-	// AdaptivePool. Items for which this item returns a negative number will
+	// AdaptivePool. Items for which this method returns a negative number will
 	// not be put back into the pool nor will be fed into statistics. This
 	// allows handling items with a virtual size, like a slice. For instance, a
 	// slice with zero cap should return -1 (or any negative value) so that it's
-	// not unnecessarily put back into the queue, while it is totally fine to
-	// return 0 for a slice with cap greater than zero. It should not hold
-	// references to the item.
+	// not unnecessarily put back into the pool, while it is totally fine to
+	// return 0 for a slice with cap greater than zero. Implementations should
+	// not hold references to the item.
 	Sizeof(T) float64
 	// Create returns a new item. It has a set of basic stats about the
 	// AdaptivePool usage that allows efficient pre-allocation in many common
@@ -140,7 +140,7 @@ func (p *AdaptivePool[T]) Get() T {
 
 // Put updates the internal statistics with the size of the object and puts
 // it back to the pool if [PoolItemProvider.Accept] allows it. Items with a
-// negative size will not be put back into the queue.
+// negative size will not be put back into the pool.
 func (p *AdaptivePool[T]) Put(x T) {
 	s := p.provider.Sizeof(x)
 	if s < 0 {

--- a/adaptive_pool.go
+++ b/adaptive_pool.go
@@ -16,7 +16,13 @@ import (
 type PoolItemProvider[T any] interface {
 	// Sizeof measures the size of an item. This measurement is used to compute
 	// stats that allow efficiently reusing and creating items in an
-	// AdaptivePool. It should not hold references to the item.
+	// AdaptivePool. Items for which this item returns a negative number will
+	// not be put back into the pool nor will be fed into statistics. This
+	// allows handling items with a virtual size, like a slice. For instance, a
+	// slice with zero cap should return -1 (or any negative value) so that it's
+	// not unnecessarily put back into the queue, while it is totally fine to
+	// return 0 for a slice with cap greater than zero. It should not hold
+	// references to the item.
 	Sizeof(T) float64
 	// Create returns a new item. It has a set of basic stats about the
 	// AdaptivePool usage that allows efficient pre-allocation in many common
@@ -31,18 +37,24 @@ type PoolItemProvider[T any] interface {
 // NormalSlice is a generic [PoolItemProvider] for slice items, operating under
 // the assumption that their `len` follow a Normal Distribution.
 type NormalSlice[T any] struct {
+	MinCap    int     // Minimum capacity of a newly created slice
 	Threshold float64 // Threshold must be non-negative.
 }
 
 // Sizeof returns the length of the slice.
 func (p NormalSlice[T]) Sizeof(v []T) float64 {
+	if cap(v) == 0 {
+		return -1
+	}
 	return float64(len(v))
 }
 
 // Create returns a new slice with length zero and cap `mean + Threshold *
 // stdDev`, or `mean` if `stdDev` is `NaN`.
 func (p NormalSlice[T]) Create(mean, stdDev float64) []T {
-	return make([]T, 0, int(normalCreateSize(mean, stdDev, p.Threshold)))
+	size := int(normalCreateSize(mean, stdDev, p.Threshold))
+	size = max(size, p.MinCap)
+	return make([]T, 0, size)
 }
 
 // Accept will accept a new item if its length is in the inclusive range `mean ±
@@ -54,13 +66,14 @@ func (p NormalSlice[T]) Accept(mean, stdDev, itemSize float64) bool {
 // NormalBytesBuffer is a [PoolItemProvider] for [*bytes.Buffer] items,
 // operating under the assumption that their `Len` follow a Normal Distribution.
 type NormalBytesBuffer struct {
+	MinCap    int     // Minimum capacity of a newly created *bytes.Buffer
 	Threshold float64 // Threshold must be non-negative.
 }
 
 // Sizeof returns the length of the buffer.
 func (p NormalBytesBuffer) Sizeof(v *bytes.Buffer) float64 {
-	if v == nil {
-		return 0
+	if v == nil || v.Cap() == 0 {
+		return -1
 	}
 	return float64(v.Len())
 }
@@ -68,8 +81,9 @@ func (p NormalBytesBuffer) Sizeof(v *bytes.Buffer) float64 {
 // Create returns a new buffer with `Len` zero and `Cap` `mean + Threshold *
 // stdDev`, or `mean` if `stdDev` is `NaN`.
 func (p NormalBytesBuffer) Create(mean, stdDev float64) *bytes.Buffer {
-	size := normalCreateSize(mean, stdDev, p.Threshold)
-	return bytes.NewBuffer(make([]byte, 0, int(size)))
+	size := int(normalCreateSize(mean, stdDev, p.Threshold))
+	size = max(size, p.MinCap)
+	return bytes.NewBuffer(make([]byte, 0, size))
 }
 
 // Accept will accept a new item if its `Len` is in the inclusive range `mean ±
@@ -80,10 +94,7 @@ func (p NormalBytesBuffer) Accept(mean, stdDev, itemSize float64) bool {
 
 // AdaptivePool is a [sync.Pool] that uses a [PoolItemProvider] to efficiently
 // create and reuse new pool items. Statistics are updated each time the `Put`
-// method is called for an item, regardless if it will be put back in the
-// sync.Pool. As with a regular sync.Pool, it can be "seeded" with objects by
-// calling `Put`, with the additional property that statistics will also be
-// seeded this way.
+// method is called for an item.
 type AdaptivePool[T any] struct {
 	pool     pool
 	provider PoolItemProvider[T]
@@ -128,9 +139,13 @@ func (p *AdaptivePool[T]) Get() T {
 }
 
 // Put updates the internal statistics with the size of the object and puts
-// it back to the pool if [PoolItemProvider.Accept] allows it.
+// it back to the pool if [PoolItemProvider.Accept] allows it. Items with a
+// negative size will not be put back into the queue.
 func (p *AdaptivePool[T]) Put(x T) {
 	s := p.provider.Sizeof(x)
+	if s < 0 {
+		return
+	}
 	mean, stdDev := p.writeThenRead(s)
 	if p.provider.Accept(mean, stdDev, s) {
 		p.pool.Put(x)

--- a/adaptive_pool_test.go
+++ b/adaptive_pool_test.go
@@ -81,11 +81,11 @@ func TestAdaptivePool(t *testing.T) {
 				break
 			}
 			i++
-			zero(t, err)
+			zero(t, err, "read CSV record #%d", i)
 			equal(t, 3, len(rec), "number of CSV values in record #%d", i)
 
 			err = parseFloats(rec, values)
-			zero(t, err)
+			zero(t, err, "parse floats from CSV record #%d; record: %v", i, rec)
 
 			x.ap.Put(v(int(values[0])))
 		}

--- a/adaptive_pool_test.go
+++ b/adaptive_pool_test.go
@@ -63,7 +63,7 @@ func TestAdaptivePool(t *testing.T) {
 		x.assertStats(15, 32, 16)
 	})
 
-	t.Run("test data", func(t *testing.T) {
+	t.Run("test data from file", func(t *testing.T) {
 		t.Parallel()
 		const thresh = 2.5
 		v := func(n int) *bytes.Buffer {

--- a/adaptive_pool_test.go
+++ b/adaptive_pool_test.go
@@ -26,7 +26,11 @@ func TestAdaptivePool(t *testing.T) {
 			return float64(cap(v))
 		}
 
-		x := newAdaptivePoolAsserter(t, NormalSlice[int]{thresh}, capv)
+		x := newAdaptivePoolAsserter(t, NormalSlice[int]{
+			Threshold: thresh,
+		}, capv)
+		x.assertStats(0, 0, math.NaN())
+		x.assertPut(nil, true) // should be a nop
 		x.assertStats(0, 0, math.NaN())
 		x.assertGet(0)
 		x.assertGet(0)            // should not change capacity
@@ -59,7 +63,7 @@ func TestAdaptivePool(t *testing.T) {
 		x.assertStats(15, 32, 16)
 	})
 
-	t.Run("seeding", func(t *testing.T) {
+	t.Run("test data", func(t *testing.T) {
 		t.Parallel()
 		const thresh = 2.5
 		v := func(n int) *bytes.Buffer {
@@ -69,7 +73,12 @@ func TestAdaptivePool(t *testing.T) {
 			return float64(v.Cap())
 		}
 
-		x := newAdaptivePoolAsserter(t, NormalBytesBuffer{thresh}, capv)
+		x := newAdaptivePoolAsserter(t, NormalBytesBuffer{
+			Threshold: thresh,
+		}, capv)
+		x.assertStats(0, 0, math.NaN())
+		x.assertPut(nil, true) // should be a nop
+		x.assertStats(0, 0, math.NaN())
 		x.assertGet(0)
 
 		values := make([]float64, 3)
@@ -130,8 +139,8 @@ func newAdaptivePoolAsserter[T any](
 func (a adaptivePoolAsserter[T]) assertGet(expectedSize float64) {
 	a.t.Helper()
 	item := a.ap.Get()
-	if s := a.provider.Sizeof(item); s != 0 {
-		a.t.Fatalf("created items should have size zero, got %v", s)
+	if s := a.provider.Sizeof(item); s > 0 {
+		a.t.Fatalf("created items should have non-positive size, got %v", s)
 	}
 	got := a.capv(item)
 	if got != expectedSize {

--- a/buffered_reader.go
+++ b/buffered_reader.go
@@ -55,7 +55,8 @@ func (p *ReaderBufferer) ReadCloser(rc io.ReadCloser) (*BufferedReader, error) {
 	return p.buf(rc, rc)
 }
 
-func (p *ReaderBufferer) buf(r io.Reader, c io.Closer) (*BufferedReader, error) {
+func (p *ReaderBufferer) buf(r io.Reader,
+	c io.Closer) (*BufferedReader, error) {
 	buf := p.bufPool.Get()
 	bytesBuf := bytes.NewBuffer(buf)
 	n, readErr := bytesBuf.ReadFrom(r)

--- a/buffered_reader.go
+++ b/buffered_reader.go
@@ -1,0 +1,223 @@
+package adaptivepool
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// ReaderBufferer buffers data from [io.Reader]s and [io.ReadCloser]s into
+// [BufferedReader]s that, upon calling their `Close` method, will put the data
+// back into an [AdaptivePool] for reuse.
+type ReaderBufferer struct {
+	bufPool AdaptivePool[[]byte]
+	rdPool  sync.Pool
+}
+
+// NewReaderBufferer returns a new ReaderBufferer. The `minCap` and `thresh`
+// arguments will be the values of the internal [NormalSlice.MinCap] and
+// [NormalSlice.Threshold], respectively. Example:
+//
+//	rb := NewReaderBufferer(512, 2, 500)
+func NewReaderBufferer(minCap int, thresh, maxN float64) *ReaderBufferer {
+	return new(ReaderBufferer).init(minCap, thresh, maxN)
+}
+
+func (p *ReaderBufferer) init(minCap int, thresh,
+	maxN float64) *ReaderBufferer {
+	p.rdPool.New = newBytesReader
+	p.bufPool.init(NormalSlice[byte]{
+		MinCap:    minCap,
+		Threshold: thresh,
+	}, maxN)
+	return p
+}
+
+func newBytesReader() any {
+	return bytes.NewReader(nil)
+}
+
+// Stats returns the statistics from the internal AdaptivePool.
+func (p *ReaderBufferer) Stats() Stats {
+	return p.bufPool.Stats()
+}
+
+// Reader buffers the contents of the given io.Reader in a BufferedReader.
+func (p *ReaderBufferer) Reader(r io.Reader) (*BufferedReader, error) {
+	return p.buf(r, nil)
+}
+
+// ReadCloser buffers the contents of the given io.ReadCloser in a
+// BufferedReader. It always calls Close, and it fails if it returns an error.
+func (p *ReaderBufferer) ReadCloser(rc io.ReadCloser) (*BufferedReader, error) {
+	return p.buf(rc, rc)
+}
+
+func (p *ReaderBufferer) buf(r io.Reader, c io.Closer) (*BufferedReader, error) {
+	buf := p.bufPool.Get()
+	bytesBuf := bytes.NewBuffer(buf)
+	n, readErr := bytesBuf.ReadFrom(r)
+	if readErr != nil && c == nil {
+		p.put(buf)
+		return nil, fmt.Errorf("read io.Reader: %w; bytes read: %v", readErr, n)
+	}
+	buf = bytesBuf.Bytes()
+
+	var closeErr error
+	if c != nil {
+		closeErr = c.Close()
+		if readErr == nil && closeErr != nil {
+			p.put(buf)
+			return nil, fmt.Errorf("close io.ReadCloser: %w; bytes read: %v",
+				closeErr, n)
+		}
+	}
+
+	if readErr != nil || closeErr != nil {
+		p.put(buf)
+		return nil, fmt.Errorf("buffer io.ReadCloser: read error: %w; close"+
+			" error: %w; bytes read: %v", readErr, closeErr, n)
+	}
+
+	rd := p.rdPool.Get().(*bytes.Reader)
+	rd.Reset(buf)
+
+	return &BufferedReader{
+		reader:  rd,
+		buf:     buf,
+		release: p.release,
+	}, nil
+}
+
+func (p *ReaderBufferer) release(buf []byte, rd *bytes.Reader) {
+	rd.Reset(nil)
+	p.rdPool.Put(rd)
+	p.put(buf)
+}
+
+func (p *ReaderBufferer) put(buf []byte) {
+	if cap(buf) > 0 {
+		clear(buf[:cap(buf)])
+		p.bufPool.Put(buf[:0])
+	}
+}
+
+// NOTE: we explicitly do not want to offer io.ReaderAt in BufferedReader
+// because, as per its docs, "Clients of ReadAt can execute parallel ReadAt
+// calls on the same input source". This means that we should add a sync.RWMutex
+// to protect the underlying implementation and make it more heavyweight in
+// order to guard the parallel ReadAt operations from potential Close
+// operations. Clients can still use the Seek method and then Read as a
+// sequential workaround.
+
+// BufferedReader holds a read-only buffer of the contents extracted from an
+// [io.Reader] or [io.ReadCloser]. Its `Close` method releases internal buffers
+// for reuse, and after that it will be empty. It is not safe for concurrent
+// use.
+type BufferedReader struct {
+	reader  *bytes.Reader
+	buf     []byte
+	release func([]byte, *bytes.Reader)
+}
+
+// Bytes returns the internal buffered []byte, transferring their ownership to
+// the caller. The data will not be later put back into a pool by the
+// implementation, and subsequent calls to any method will behave as if `Close`
+// had been called. Subsequent calls to this method return nil, the same as if
+// `Close` had been called before.
+func (bb *BufferedReader) Bytes() []byte {
+	if bb.reader != nil {
+		bb.release(nil, bb.reader)
+		buf := bb.buf
+		*bb = BufferedReader{}
+		return buf
+	}
+	return nil
+}
+
+// Len returns the number of unread bytes.
+func (bb *BufferedReader) Len() int {
+	if bb.reader != nil {
+		return bb.reader.Len()
+	}
+	return 0
+}
+
+// Read is part of the implementation of the io.Reader interface.
+func (bb *BufferedReader) Read(p []byte) (int, error) {
+	if bb.reader != nil {
+		return bb.reader.Read(p)
+	}
+	return 0, io.EOF
+}
+
+// Close is part of the implementation of the io.Closer interface. This method
+// releases the internal buffer for reuse. After this, the *BufferedReader will
+// be empty. This method is idempotent and always returns a nil error.
+func (bb *BufferedReader) Close() error {
+	if bb.reader != nil {
+		bb.release(bb.buf, bb.reader)
+		*bb = BufferedReader{}
+	}
+	return nil
+}
+
+// Seek is part of the implementation of the io.Seeker interface.
+func (bb *BufferedReader) Seek(offset int64, whence int) (int64, error) {
+	if bb.reader != nil {
+		return bb.reader.Seek(offset, whence)
+	}
+
+	switch whence {
+	case io.SeekStart, io.SeekCurrent, io.SeekEnd:
+	default:
+		return 0, errors.New("BufferedReader.Seek: invalid whence")
+	}
+	if offset < 0 {
+		return 0, errors.New("BufferedReader.Seek: negative position")
+	}
+
+	return 0, nil
+}
+
+// ReadByte is part of the implementation of the io.ByteReader interface.
+func (bb *BufferedReader) ReadByte() (byte, error) {
+	if bb.reader != nil {
+		return bb.reader.ReadByte()
+	}
+	return 0, io.EOF
+}
+
+// UnreadByte is part of the implementation of the io.ByteScanner interface.
+func (bb *BufferedReader) UnreadByte() error {
+	if bb.reader != nil {
+		return bb.reader.UnreadByte()
+	}
+	return errors.New("BufferedReader.UnreadByte: resource closed")
+}
+
+// ReadRune is part of the implementation of the io.RuneReader interface.
+func (bb *BufferedReader) ReadRune() (r rune, size int, err error) {
+	if bb.reader != nil {
+		return bb.reader.ReadRune()
+	}
+	return 0, 0, io.EOF
+}
+
+// UnreadRune is part of the implementation of the io.RuneScanner interface.
+func (bb *BufferedReader) UnreadRune() error {
+	if bb.reader != nil {
+		return bb.reader.UnreadRune()
+	}
+	return errors.New("BufferedReader.UnreadRune: resource closed")
+}
+
+// WriteTo is part of the implementation of the io.WriterTo interface.
+func (bb *BufferedReader) WriteTo(w io.Writer) (n int64, err error) {
+	if bb.reader != nil {
+		return bb.reader.WriteTo(w)
+	}
+	return 0, nil
+}

--- a/buffered_reader_test.go
+++ b/buffered_reader_test.go
@@ -1,0 +1,338 @@
+package adaptivepool
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"testing"
+	"testing/iotest"
+)
+
+// testData with non-ASCII characters at the beginning to test the ReadRune
+// method correctly returning UTF-8 runes.
+const testData = `痛苦
+	I was looking for a job and then I found a job
+	And Heaven knows, I'm miserable now
+`
+
+var _ interface { // assert interfaces from standard library
+	io.ReadSeekCloser
+	io.ByteScanner
+	io.RuneScanner
+	io.WriterTo
+} = (*BufferedReader)(nil)
+
+func TestReaderBufferer(t *testing.T) {
+	t.Parallel()
+	errTest := errors.New("hated because of great qualities")
+	errTest2 := errors.New("loved despite of great faults")
+
+	t.Run("Reader: happy path - empty", func(t *testing.T) {
+		t.Parallel()
+		brr := NewReaderBufferer(512, 2, 500)
+
+		br, err := brr.Reader(bytes.NewReader(nil))
+		zero(t, err, "Reader error on empty io.Reader")
+		equal(t, true, br != nil, "nil Reader")
+
+		zero(t, iotest.TestReader(br, nil),
+			"iotest.TestReader error on non-closed *BufferedReader")
+		// first call Bytes on br so we later don't put it back into the pool.
+		// This is because if Bytes is called, then the buffer no longer belongs
+		// to us
+		finishAndTestBufferedReader(t, br, false)
+
+		st := brr.Stats()
+		zero(t, st.N(), "should not have been put back into the pool")
+	})
+
+	t.Run("ReadCloser: happy path - non-empty", func(t *testing.T) {
+		t.Parallel()
+		brr := NewReaderBufferer(512, 2, 500)
+
+		rc := io.NopCloser(bytes.NewReader([]byte(testData)))
+		br, err := brr.ReadCloser(rc)
+		zero(t, err, "Reader error on non-empty io.Reader")
+		equal(t, true, br != nil, "nil Reader")
+
+		zero(t, iotest.TestReader(br, []byte(testData)),
+			"iotest.TestReader error on non-closed *BufferedReader")
+		finishAndTestBufferedReader(t, br, true)
+
+		st := brr.Stats()
+		equal(t, 1, st.N(), "should have been put back into the pool")
+	})
+
+	t.Run("Reader: fail reading", func(t *testing.T) {
+		t.Parallel()
+		brr := NewReaderBufferer(512, 2, 500)
+
+		br, err := brr.Reader(iotest.ErrReader(errTest))
+		equal(t, true, errors.Is(err, errTest), "should have failed reading")
+		zero(t, br, "should return nil on error")
+	})
+
+	t.Run("ReadCloser: fail reading", func(t *testing.T) {
+		t.Parallel()
+		brr := NewReaderBufferer(512, 2, 500)
+
+		rc := io.NopCloser(iotest.ErrReader(errTest))
+		br, err := brr.ReadCloser(rc)
+		equal(t, true, errors.Is(err, errTest), "should have failed reading")
+		zero(t, br, "should return nil on error")
+	})
+
+	t.Run("ReadCloser: fail closing", func(t *testing.T) {
+		t.Parallel()
+		brr := NewReaderBufferer(512, 2, 500)
+
+		rc := readCloser{
+			Reader: bytes.NewReader(nil),
+			Closer: closerFunc(func() error { return errTest }),
+		}
+		br, err := brr.ReadCloser(rc)
+		equal(t, true, errors.Is(err, errTest), "should have failed closing")
+		zero(t, br, "should return nil on error")
+	})
+
+	t.Run("ReadCloser: fail reading and closing", func(t *testing.T) {
+		t.Parallel()
+		brr := NewReaderBufferer(512, 2, 500)
+
+		rc := readCloser{
+			Reader: iotest.ErrReader(errTest),
+			Closer: closerFunc(func() error { return errTest2 }),
+		}
+		br, err := brr.ReadCloser(rc)
+		equal(t, true, errors.Is(err, errTest), "should have failed reading")
+		equal(t, true, errors.Is(err, errTest2), "should have failed closing")
+		zero(t, br, "should return nil on error")
+	})
+}
+
+type readCloser struct {
+	io.Reader
+	io.Closer
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
+
+func newTestBufferedReader(buf []byte) *BufferedReader {
+	return &BufferedReader{
+		reader:  bytes.NewReader(buf),
+		buf:     buf,
+		release: func([]byte, *bytes.Reader) {},
+	}
+}
+
+func TestBufferedReader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without data - Close then Bytes", func(t *testing.T) {
+		t.Parallel()
+		br := newTestBufferedReader(nil)
+		zero(t, iotest.TestReader(br, nil),
+			"iotest.TestReader error on non-closed *BufferedReader")
+		finishAndTestBufferedReader(t, br, true)
+	})
+
+	t.Run("without data - Bytes then Close", func(t *testing.T) {
+		t.Parallel()
+		br := newTestBufferedReader(nil)
+		zero(t, iotest.TestReader(br, nil),
+			"iotest.TestReader error on non-closed *BufferedReader")
+		finishAndTestBufferedReader(t, br, false)
+	})
+
+	t.Run("with data - Close then Bytes", func(t *testing.T) {
+		t.Parallel()
+		br := newTestBufferedReader([]byte(testData))
+		zero(t, iotest.TestReader(br, []byte(testData)),
+			"iotest.TestReader error on non-closed *BufferedReader")
+		finishAndTestBufferedReader(t, br, true)
+	})
+
+	t.Run("with data - Bytes then Close", func(t *testing.T) {
+		t.Parallel()
+		br := newTestBufferedReader([]byte(testData))
+		zero(t, iotest.TestReader(br, []byte(testData)),
+			"iotest.TestReader error on non-closed *BufferedReader")
+		finishAndTestBufferedReader(t, br, false)
+	})
+}
+
+func finishAndTestBufferedReader(t *testing.T, br *BufferedReader,
+	// true: call Close first, then Bytes; false: call Bytes first, then Close
+	closeFirst bool,
+) {
+	finishAndTestBufferedReaderInternal(t, br, closeFirst, true)
+}
+
+func finishAndTestBufferedReaderInternal(t *testing.T, br *BufferedReader,
+	closeFirst bool, runTheOtherAfter bool) {
+	t.Helper()
+
+	_, err := br.Seek(0, io.SeekStart)
+	zero(t, err, "Seek(0, io.SeekStart)")
+
+	if l := br.Len(); l > 0 {
+		// io.ByteScanner methods
+		_, err := br.ReadByte()
+		zero(t, err, "ReadByte on non-empty *BufferedReader")
+
+		gotL := br.Len()
+		equal(t, l-1, gotL, "should have one less byte; want: %d, got: %d", l-1,
+			gotL)
+
+		err = br.UnreadByte()
+		zero(t, err, "UnreadByte after ReadByte")
+
+		gotL = br.Len()
+		equal(t, l, gotL, "should have the same original length; want: %d, "+
+			"got: %d", l-1, gotL)
+
+		// io.RuneScanner methods
+		_, s, err := br.ReadRune()
+		zero(t, err, "ReadRune on non-empty *BufferedReader")
+		if s < 2 {
+			t.Fatalf("unexpected rune size %d from non-empty *BufferedReader "+
+				"(remember to use test data starting with non-ASCII, wide "+
+				"characters", s)
+		}
+
+		gotL = br.Len()
+		wantL := l - s
+		equal(t, wantL, gotL, "should have %d less byte(s); want: %d, got: %d",
+			s, wantL, gotL)
+
+		err = br.UnreadRune()
+		zero(t, err, "UnreadRune after ReadRune")
+
+		gotL = br.Len()
+		equal(t, l, gotL, "should have the same original length; want: %d, "+
+			"got: %d", l-1, gotL)
+	}
+
+	if closeFirst {
+		zero(t, br.Close(), "close *BufferedReader")
+		zero(t, br.Close(), "close *BufferedReader for the second time")
+
+	} else {
+		_, err := br.Seek(0, io.SeekStart)
+		zero(t, err, "Seek(0, io.SeekStart)")
+		l := br.Len()
+
+		buf := new(bytes.Buffer)
+		gotL, err := br.WriteTo(buf)
+		zero(t, err, "WriteTo")
+		equal(t, int64(l), gotL, "unexpected read buf with length %d, "+
+			"expected length %d; data: %q", gotL, l, buf.String())
+
+		wantBuf := buf.Bytes()
+		gotBuf := br.Bytes()
+		equal(t, true, slices.Equal(wantBuf, gotBuf), "should return same "+
+			"data\n\twant: %q\n\tgot: %q", wantBuf, gotBuf)
+
+		if !runTheOtherAfter {
+			zero(t, len(wantBuf), "no data should be read after closing, "+
+				"got: %q", wantBuf)
+			zero(t, len(gotBuf), "no data should be returned after closing, "+
+				"got: %q", gotBuf)
+		}
+
+	}
+
+	zero(t, br.Len(), "should have length zero after closing")
+	zero(t, iotest.TestReader(br, nil),
+		"iotest.TestReader error on closed *BufferedReader")
+
+	// as a closed *BufferedReader will no longer use its internal
+	// *bytes.Reader, we will test that once closed it behaves the same as an
+	// empty one, hence we compare all its ouputs. When comparing errors, we
+	// will prioritize detecting io.EOF, otherwise just make sure they both err
+	// under the same conditions
+
+	isEOF := func(err error) string {
+		if errors.Is(err, io.EOF) {
+			return "yes"
+		}
+		return fmt.Sprintf("no, it is %v", err)
+	}
+
+	compareErrs := func(want, got error) error {
+		if (want == nil) != (got == nil) {
+			return fmt.Errorf("want error: %w; got error: %w", want, got)
+		}
+		if errors.Is(want, io.EOF) != errors.Is(got, io.EOF) {
+			return fmt.Errorf("disagree on io.EOF; want error is io.EOF: %v; "+
+				"got error is io.EOF: %v", isEOF(want), isEOF(got))
+		}
+		return nil
+	}
+
+	emptyBytesReader := bytes.NewReader(nil)
+
+	wantInt, wantErr := emptyBytesReader.Read(make([]byte, 10))
+	gotInt, gotErr := br.Read(make([]byte, 10))
+	zero(t, compareErrs(wantErr, gotErr), "disagree on Read error after close")
+	equal(t, wantInt, gotInt, "disagree on Read int after close")
+
+	wantInt64, wantErr := emptyBytesReader.Seek(0, io.SeekStart)
+	gotInt64, gotErr := br.Seek(0, io.SeekStart)
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on Seek(0, io.SeekStart) error after close")
+	equal(t, wantInt64, gotInt64,
+		"disagree on Seek(0, io.SeekStart) int64 after close")
+
+	wantInt64, wantErr = emptyBytesReader.Seek(-1, io.SeekStart)
+	gotInt64, gotErr = br.Seek(-1, io.SeekStart)
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on Seek(-1, io.SeekStart) error after close")
+	equal(t, wantInt64, gotInt64,
+		"disagree on Seek(-1, io.SeekStart) int64 after close")
+
+	wantInt64, wantErr = emptyBytesReader.Seek(0, -1)
+	gotInt64, gotErr = br.Seek(0, -1)
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on Seek(0, -1) error after close")
+	equal(t, wantInt64, gotInt64,
+		"disagree on Seek(0, -1) int64 after close")
+
+	wantByte, wantErr := emptyBytesReader.ReadByte()
+	gotByte, gotErr := br.ReadByte()
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on ReadByte error after close")
+	equal(t, wantByte, gotByte,
+		"disagree on ReadByte byte after close")
+
+	wantErr = emptyBytesReader.UnreadByte()
+	gotErr = br.UnreadByte()
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on UnreadByte error after close")
+
+	wantRune, wantInt, wantErr := emptyBytesReader.ReadRune()
+	gotRune, gotInt, gotErr := br.ReadRune()
+	zero(t, compareErrs(wantErr, gotErr), "disagree on ReadRune error after close")
+	equal(t, wantInt, gotInt, "disagree on ReadRune int after close")
+	equal(t, wantRune, gotRune, "disagree on ReadRune rune after close")
+
+	wantErr = emptyBytesReader.UnreadRune()
+	gotErr = br.UnreadRune()
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on UnreadRune error after close")
+
+	wantInt64, wantErr = emptyBytesReader.WriteTo(io.Discard)
+	gotInt64, gotErr = br.WriteTo(io.Discard)
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on WriteTo error after close")
+	equal(t, wantInt64, gotInt64,
+		"disagree on WriteTo int64 after close")
+
+	if runTheOtherAfter {
+		finishAndTestBufferedReaderInternal(t, br, !closeFirst, false)
+	}
+}

--- a/buffered_reader_test.go
+++ b/buffered_reader_test.go
@@ -316,7 +316,8 @@ func finishAndTestBufferedReaderInternal(t *testing.T, br *BufferedReader,
 
 	wantRune, wantInt, wantErr := emptyBytesReader.ReadRune()
 	gotRune, gotInt, gotErr := br.ReadRune()
-	zero(t, compareErrs(wantErr, gotErr), "disagree on ReadRune error after close")
+	zero(t, compareErrs(wantErr, gotErr),
+		"disagree on ReadRune error after close")
 	equal(t, wantInt, gotInt, "disagree on ReadRune int after close")
 	equal(t, wantRune, gotRune, "disagree on ReadRune rune after close")
 

--- a/stats.go
+++ b/stats.go
@@ -41,9 +41,11 @@ func (s *Stats) MaxN() float64 { return math.Round(s.maxN) }
 // values, improving the adaptability to seasonal changes in data distribution.
 // Using a value less than one disables this behaviour. If the current value of
 // N is already higher, then it will be set to `maxN` immediately. A value too
-// low may cause too much disturbance, while a value too high may reduce
-// adaptability. A recommended starting value is 500, if your application can
-// tolerate it, and probably no less than 100 otherwise.
+// low may cause instability, while a value too high may reduce adaptability.
+//
+// NOTE: A recommended starting value is 500, if your application can tolerate
+// it, and probably no less than 100 otherwise. This recommendation could change
+// in future versions.
 func (s *Stats) SetMaxN(maxN float64) {
 	if maxN < 1 {
 		maxN = 0

--- a/stats.go
+++ b/stats.go
@@ -40,7 +40,10 @@ func (s *Stats) MaxN() float64 { return math.Round(s.maxN) }
 // incremented beyond `maxN`. This is useful to keep a bias towards latest
 // values, improving the adaptability to seasonal changes in data distribution.
 // Using a value less than one disables this behaviour. If the current value of
-// N is already higher, then it will be set to `maxN` immediately.
+// N is already higher, then it will be set to `maxN` immediately. A value too
+// low may cause too much disturbance, while a value too high may reduce
+// adaptability. A recommended starting value is 500, if your application can
+// tolerate it, and probably no less than 100 otherwise.
 func (s *Stats) SetMaxN(maxN float64) {
 	if maxN < 1 {
 		maxN = 0

--- a/stats_test.go
+++ b/stats_test.go
@@ -61,6 +61,9 @@ func TestStats(t *testing.T) {
 	//	errRelPerc<10 at N=6
 	//	errRelPerc<5  at N=11
 	//	errRelPerc<1  at N=51
+	//
+	// NOTE: this could mean that 100 (or 500 for some comfort, if the
+	// application allows it) would be a reasonable starting value for `maxN`.
 	const (
 		xShift = -1
 		a      = 30

--- a/stats_test.go
+++ b/stats_test.go
@@ -113,7 +113,7 @@ func testStats(t *testing.T, st stats, meanErrOK, sdErrOK errTestFunc) {
 	t.Helper()
 	cr := csvTestDataReader(t)
 
-	zero(t, st.Mean())
+	zero(t, st.Mean(), "Mean in zero value")
 	sd := st.StdDev()
 	equal(t, true, math.IsNaN(sd), "unexpected non-NaN std dev for"+
 		" non-initialized stats: %v", sd)
@@ -124,11 +124,11 @@ func testStats(t *testing.T, st stats, meanErrOK, sdErrOK errTestFunc) {
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		zero(t, err)
+		zero(t, err, "read CSV record #%d", i)
 		equal(t, 3, len(rec), "number of CSV values in record #%d", i)
 
 		err = parseFloats(rec, v)
-		zero(t, err)
+		zero(t, err, "parse floats from CSV record #%d; record: %v", i, rec)
 
 		st.Push(v[0])
 		n := st.N()
@@ -145,7 +145,7 @@ func testStats(t *testing.T, st stats, meanErrOK, sdErrOK errTestFunc) {
 	}
 
 	st.Reset()
-	zero(t, st.Mean())
+	zero(t, st.Mean(), "Mean after Reset")
 	sd = st.StdDev()
 	equal(t, true, math.IsNaN(sd), "unexpected non-NaN std dev for"+
 		" cleared stats: %v", sd)
@@ -155,20 +155,20 @@ func TestStatsMaxN(t *testing.T) {
 	t.Parallel()
 
 	st := new(Stats)
-	zero(t, st.MaxN())
+	zero(t, st.MaxN(), "MaxN in zero value")
 	st.SetMaxN(0.1)
-	zero(t, st.MaxN())
+	zero(t, st.MaxN(), "MaxN should not change if set to number < 1")
 	st.SetMaxN(-1)
-	zero(t, st.MaxN())
+	zero(t, st.MaxN(), "MaxN should not change if set to number < 1")
 
 	st.Push(1)
 	st.Push(1)
 	st.Push(1)
 	st.Push(1)
 
-	st.SetMaxN(1)
-	equal(t, 1, st.MaxN(), "maxN")
-	equal(t, 1, st.N(), "maxN")
+	st.SetMaxN(1.1)
+	equal(t, 1, st.MaxN(), "maxN should be round to nearest integer")
+	equal(t, 1, st.N(), "N should have been capped to maxN")
 
 	st.SetMaxN(0)
 	st.Push(1)

--- a/utils_test.go
+++ b/utils_test.go
@@ -32,10 +32,10 @@ func equal[T comparable](tb testing.TB, expected, got T, msg string,
 	}
 }
 
-func zero(tb testing.TB, v any) {
+func zero(tb testing.TB, v any, msg string, args ...any) {
 	tb.Helper()
 	if v != nil && !reflect.ValueOf(v).IsZero() {
-		tb.Fatalf("unexpected non-zero value: %v", v)
+		tb.Fatalf("%sunexpected non-zero value: %v", msgFmt(msg, args...), v)
 	}
 }
 
@@ -57,7 +57,7 @@ func csvTestDataReader(tb testing.TB) *csv.Reader {
 	// discard the CSV header
 	for {
 		_, isPrefix, err := r.ReadLine()
-		zero(tb, err)
+		zero(tb, err, "ReadLine from test data")
 		if !isPrefix {
 			break
 		}
@@ -77,15 +77,15 @@ func allTestDataInputValues(tb testing.TB) []float64 {
 	ret := make([]float64, 0, 10_000)
 
 	cr := csvTestDataReader(tb)
-	for {
+	for i := 1; ; i++ {
 		rec, err := cr.Read()
 		if errors.Is(err, io.EOF) {
 			break
 		}
-		zero(tb, err)
+		zero(tb, err, "read CSV record #%d", i)
 
 		f, err := strconv.ParseFloat(rec[0], 64)
-		zero(tb, err)
+		zero(tb, err, "parse first float value from record #%d", i)
 
 		ret = append(ret, f)
 	}


### PR DESCRIPTION
- Add ReaderBufferer with its child struct BufferedReader
- AdaptivePool:
  - Add MinCap to NormalSlice and NormalBytesBuffer
  - Change PoolItemProvider.Sizeof to have a meaningful negative value
  - AdaptivePool.Put will not reuse items with negative size
- Stats: remove legacy implementations
- Improve docs and add recommended starting values